### PR TITLE
fix(security): escape JSON-LD output and widen audit redaction

### DIFF
--- a/src/misc/utils/html/jsonLd.test.ts
+++ b/src/misc/utils/html/jsonLd.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { escapeJsonLd, serializeJsonLd } from '@/misc/utils/html/jsonLd.js';
+
+test('JSON-LD serialisation cannot close its own script block', () => {
+  // pass.videoLink is stored verbatim when it matches no known video host, so
+  // this is the shape an attacker can persist through a pass submission.
+  const payload = {
+    '@type': 'VideoObject',
+    url: 'https://evil.example/</script><script>alert(document.domain)</script>',
+  };
+
+  const serialized = serializeJsonLd(payload);
+
+  assert.equal(serialized.includes('</script>'), false);
+  assert.equal(serialized.includes('<'), false);
+  assert.equal(serialized.includes('>'), false);
+  // Still valid JSON, and the value round-trips unchanged.
+  assert.equal(JSON.parse(serialized).url, payload.url);
+});
+
+test('JSON-LD escaping covers ampersands and JS line terminators', () => {
+  assert.equal(escapeJsonLd('"a&b"'), '"a\\u0026b"');
+  assert.equal(escapeJsonLd('"a\u2028b"'), '"a\\u2028b"');
+  assert.equal(escapeJsonLd('"a\u2029b"'), '"a\\u2029b"');
+});

--- a/src/misc/utils/html/jsonLd.ts
+++ b/src/misc/utils/html/jsonLd.ts
@@ -1,0 +1,37 @@
+/**
+ * Serialisation helper for JSON-LD blocks that get inlined into server-rendered
+ * HTML (`src/server/middleware/html-meta.ts`).
+ *
+ * Kept in its own module — free of model/config imports — so the escaping rule
+ * can be unit tested without booting Sequelize.
+ */
+
+/**
+ * Escape a `JSON.stringify` result so it is safe inside
+ * `<script type="application/ld+json"> … </script>`.
+ *
+ * `JSON.stringify` escapes nothing the HTML tokenizer cares about, so a value
+ * containing `</script>` closes the block early and everything after it is
+ * parsed as markup. Not every value that reaches the JSON-LD blocks is trusted:
+ * `pass.videoLink` is stored verbatim whenever it fails to match a known
+ * YouTube/Bilibili pattern (see `cleanSingleVideoUrl`), so it can carry
+ * arbitrary non-whitespace text straight from a pass submission.
+ *
+ * Escaping `<` and `>` makes any closing sequence unreachable, and `&` is
+ * escaped so the `\uXXXX` output cannot itself be spoofed. U+2028/U+2029 are
+ * legal inside JSON strings but are line terminators to older JS parsers, so
+ * they are escaped too.
+ */
+export function escapeJsonLd(json: string): string {
+  return json
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/** Serialise a value into an escaped, inline-safe JSON-LD script body. */
+export function serializeJsonLd(block: unknown): string {
+  return escapeJsonLd(JSON.stringify(block));
+}

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -272,7 +272,13 @@ const auditLogMiddleware: MiddlewareFunction = async (req: Request, res: Respons
       return oldJson.call(this, body);
     };
     res.send = function (body: any) {
-      responseBody = JSON.parse(body);
+      // res.send carries any payload type; a non-JSON body used to throw here
+      // and turn a successful handler into a 500.
+      try {
+        responseBody = typeof body === 'string' ? JSON.parse(body) : body;
+      } catch {
+        responseBody = undefined;
+      }
       return oldSend.call(this, body);
     };
 

--- a/src/server/middleware/html-meta.ts
+++ b/src/server/middleware/html-meta.ts
@@ -19,6 +19,7 @@ import { getPrimaryVideoLink } from '@/misc/utils/data/videoLinkParts.js';
 import Song from '@/models/songs/Song.js';
 import Artist from '@/models/artists/Artist.js';
 import {fetchFrontendJson} from '@/server/services/core/FrontendContentService.js';
+import {serializeJsonLd} from '@/misc/utils/html/jsonLd.js';
 
 const SITE_NAME = 'The Universal Forums';
 const DEFAULT_DESCRIPTION =
@@ -33,12 +34,15 @@ const levelSongInclude = {
 const buildJsonLdScripts = (data: object | object[]) => {
   const blocks = Array.isArray(data) ? data : [data];
   return blocks
-    .map((block) => `<script type="application/ld+json">${JSON.stringify(block)}</script>`)
+    .map(
+      (block) =>
+        `<script type="application/ld+json">${serializeJsonLd(block)}</script>`,
+    )
     .join('\n          ');
 };
 
 const buildCanonicalTag = (path: string) =>
-  `<link rel="canonical" href="${clientUrlEnv}${path}" />`;
+  `<link rel="canonical" href="${clientUrlEnv}${escapeHtml(path)}" />`;
 
 // Add type for manifest entries
 type ManifestEntry = {
@@ -281,7 +285,8 @@ export const htmlMetaMiddleware = async (
           `${playerName} cleared ${songName} by ${artistName} — ${difficultyName} · Score ${pass.scoreV2}`,
         );
         const canonicalPath = req.path;
-        const pageUrl = `${clientUrlEnv}${canonicalPath}`;
+        // canonicalPath is the raw request path; escape before it lands in an attribute.
+        const pageUrl = escapeHtml(`${clientUrlEnv}${canonicalPath}`);
         const thumbnailUrl = `${ownUrl}/v2/media/thumbnail/pass/${id}`;
 
         metaTags = `
@@ -339,7 +344,8 @@ export const htmlMetaMiddleware = async (
           `${songName} by ${artistName} — charted by ${creators} on ${SITE_NAME}`,
         );
         const canonicalPath = req.path;
-        const pageUrl = `${clientUrlEnv}${canonicalPath}`;
+        // canonicalPath is the raw request path; escape before it lands in an attribute.
+        const pageUrl = escapeHtml(`${clientUrlEnv}${canonicalPath}`);
         const thumbnailUrl = `${ownUrl}/v2/media/thumbnail/level/${id}`;
 
         metaTags = `
@@ -358,7 +364,7 @@ export const htmlMetaMiddleware = async (
           <meta property="twitter:title" content="${pageTitle}" />
           <meta property="twitter:description" content="${pageDescription}" />
           <meta property="twitter:image" content="${thumbnailUrl}" />
-          <meta name="theme-color" content="${level.difficulty?.color || '#090909'}" />
+          <meta name="theme-color" content="${escapeHtml(level.difficulty?.color || '#090909')}" />
           <meta property="og:url" content="${pageUrl}" />
           ${buildJsonLdScripts([
             {
@@ -391,7 +397,8 @@ export const htmlMetaMiddleware = async (
           `Check out ${playerName}'s profile, clears, and achievements on ${SITE_NAME}`,
         );
         const canonicalPath = req.path;
-        const pageUrl = `${clientUrlEnv}${canonicalPath}`;
+        // canonicalPath is the raw request path; escape before it lands in an attribute.
+        const pageUrl = escapeHtml(`${clientUrlEnv}${canonicalPath}`);
         const thumbnailUrl = `${ownUrl}/v2/media/thumbnail/player/${id}`;
 
         metaTags = `
@@ -442,7 +449,8 @@ export const htmlMetaMiddleware = async (
           `Level pack ${packName} by ${ownerName} on ${SITE_NAME}`,
         );
         const canonicalPath = `/packs/${pack.linkCode}`;
-        const pageUrl = `${clientUrlEnv}${canonicalPath}`;
+        // linkCode is stored data; escape before it lands in an attribute.
+        const pageUrl = escapeHtml(`${clientUrlEnv}${canonicalPath}`);
         const thumbnailUrl = `${ownUrl}/v2/media/thumbnail/pack/${pack.linkCode}`;
 
         metaTags = `

--- a/src/server/services/core/AuditLogService.ts
+++ b/src/server/services/core/AuditLogService.ts
@@ -27,8 +27,10 @@ const SENSITIVE_AUDIT_KEYS = new Set([
   'accesstoken',
   'csrftoken',
   'captchatoken',
+  'confirmpassword',
   'secret',
   'clientsecret',
+  'apikey',
   'authorization',
   'x-super-admin-password',
 ]);


### PR DESCRIPTION
Findings from a security pass over the request-handling paths, rebased onto `08ba5962` (passkeys).

Most of the original set turned out to be fixed independently in that commit — ingest-key timing compares, `addUserToRequest`, the super-admin password gate, the team-alias SQL injection (via the teams service refactor), audit-log redaction, and the `github-asset` proxy (commented out). Several of those fixes are better than what I had, so they were kept and mine dropped. What remains here is what `08ba5962` did not reach.

---

## 1. Stored XSS through the JSON-LD blocks — `src/server/middleware/html-meta.ts`

### What was wrong

`buildJsonLdScripts` put `JSON.stringify` output directly inside an inline `<script>` element:

```js
`<script type="application/ld+json">${JSON.stringify(block)}</script>`
```

`JSON.stringify` escapes quotes and control characters. It does **not** escape `<`, `>`, or `/` — none of them are special in JSON. But `</script>` *is* special to the HTML tokenizer, and it ends a script element no matter where it appears inside one. So any string in the block that contains `</script>` terminates the JSON-LD element early, and the browser parses whatever follows as markup.

You can see it without touching the app:

```js
JSON.stringify({ url: "a</script><script>alert(1)</script>" })
// {"url":"a</script><script>alert(1)</script>"}
```

Dropped into the template, the first `</script>` closes the `ld+json` block and the second element executes.

### Why it was reachable

The `/passes/:id` block feeds `pass.videoLink` into the `VideoObject` JSON-LD:

```js
url: getPrimaryVideoLink(pass.videoLink) || pageUrl,
```

`videoLink` is not sanitised HTML. `cleanVideoUrl` → `cleanVideoLinks` → `cleanSingleVideoUrl`, and that last function canonicalises URLs matching known YouTube/Bilibili patterns and returns everything else **unchanged** — its own doc comment says so ("Unknown URLs pass through unchanged"). The admin edit paths run it through `sanitizeTextInput`, which is `trim()` + `slice(0, 1000)` — no HTML handling at all.

`splitVideoLinks` splits on whitespace and takes the first token, so a payload just has to contain no spaces. `</script><script>alert(document.domain)</script>` has none.

The `escapeHtml` sweep in `08ba5962` moved every `escapeMetaText` call to the shared helper, but it only covers the `<meta>` values. The JSON-LD blocks are built on a separate path and were untouched.

### How to reproduce

1. Submit a pass with a `videoLink` that matches no known video host and carries the breakout, e.g.
   `https://x.invalid/a</script><script>alert(document.domain)</script>`
   (must match no pattern in `cleanSingleVideoUrl` — a real YouTube URL gets rewritten to `https://www.youtube.com/watch?v=<id>` and the payload is stripped.)
2. Have it approved so it becomes a `Pass` row. A super admin can also set the field directly via `PUT /v2/database/passes/:id`.
3. Load `/passes/<id>` and view source.

Before this change, the served HTML contains a closed `ld+json` block followed by a live `<script>`. After it, the payload appears as `</script>` inside the JSON and the block stays intact.

### Worst case

The payload runs as first-party script on the origin serving those routes — the same origin as the signed-in app. `accessToken` and `refreshToken` are `httpOnly`, so the script cannot read them directly, but that is not much protection here:

- The cookies are `SameSite=None; Secure`, so they are attached automatically to requests the script makes to the API.
- `csrfToken` is deliberately **not** `httpOnly` (`CSRF_COOKIE_OPTIONS`, for the double-submit pattern), so the script can read it and set `x-csrf-token`.

Together that means injected script can issue fully authenticated, CSRF-valid requests as whoever is viewing the page. Change their email, add a passkey, drive any endpoint their permissions allow. If a rater or super admin opens the page, it runs with those permissions.

Delivery is the uncomfortable part: `/passes/:id` is exactly the URL people paste into Discord, and this middleware exists to render embeds for it. A malicious pass link in a busy channel is a one-click, self-spreading trigger — and the attacker only needs a pass approved, which is a normal thing to ask for.

### The fix

New `src/misc/utils/html/jsonLd.ts` — `serializeJsonLd()` escapes `<`, `>`, `&`, U+2028 and U+2029 into `\uXXXX` escapes after stringifying. Output stays valid JSON and round-trips to the identical value, so structured-data consumers are unaffected; `</script>` simply becomes unrepresentable.

It is a standalone module with no model or config imports, so `jsonLd.test.ts` can assert the rule without booting Sequelize. The test uses the actual attack string as its input.

---

## 2. Unescaped values in meta attributes — `src/server/middleware/html-meta.ts`

`canonicalPath` (from `req.path`) went into `href="..."` and `content="..."` raw, as did `level.difficulty?.color` in `theme-color`.

Both now go through `escapeHtml`.

**Honest scoping:** this one is weaker than it looks. `req.path` is *not* URL-decoded, and browsers percent-encode `<`, `>` and `"` in the path before sending, so `%22` arrives as the literal text `%22` and never breaks the attribute. Reaching it needs a client that sends raw quotes in a request path — a non-browser client, a crawler, or a proxy that rewrites. `difficulty.color` is staff-set. So: real unescaped interpolation, low practical reachability. Fixed because it costs one function call and removes the need to reason about who can send what path.

---

## 3. Two credential field names missing from audit redaction — `src/server/services/core/AuditLogService.ts`

`08ba5962` added `redactForAudit` and a `SENSITIVE_AUDIT_KEYS` set, which is the right layer for this. Two live field names were not in it:

- `confirmPassword` — used in registration and password-change forms
- `apiKey`

`auditLogMiddleware` persists `req.body` on every successful mutating request under a privileged guard, so anything not in that set is written to `audit_logs.payload` in plaintext and kept for the two-month retention window.

Worst case is a credential store nobody thinks of as one: read access to `audit_logs` (a DB dump, a backup, an over-broad support query) yields plaintext passwords for every account that changed one. Both keys added.

---

## 4. `res.send` override could 500 a successful handler — `src/server/middleware/auth.ts`

```js
res.send = function (body: any) {
  responseBody = JSON.parse(body);   // unguarded
  return oldSend.call(this, body);
};
```

`res.send` accepts strings, Buffers, objects and arrays. `JSON.parse` on anything non-JSON throws, and it throws *synchronously inside `res.send`* — so a handler that did its work correctly and called `res.send('OK')` turns into a 500 after the side effects already landed.

Not a vulnerability, but it sits on every audited mutating route, and the failure mode is "the write succeeded and the client was told it failed", which invites retries on non-idempotent endpoints. Now wrapped in try/catch, with objects passed through instead of re-parsed.

---

## Verification

- `npx tsc --project tsconfig.json --noEmit` — clean
- `npm run lint` (the `.eslintrc.security.cjs` build gate) — clean
- `npm test` — 10/10 pass, including the two new JSON-LD cases

## Note unrelated to this PR

`08ba5962` added `@simplewebauthn/server` to `package.json` without updating `package-lock.json`, so `npm ci` fails on that commit. The lockfile change is deliberately **not** included here to keep this diff to the security fixes — worth a separate commit.

## Reviewed and not changed

I went looking for a bypass in the new passkey code and did not find one — unique indexes on `credentialId` and `challenge`, challenges stored server-side and type-tagged and TTL'd and single-use, step-up required to both add and remove, fail-closed rate limits on every unauthenticated endpoint, MFA bound to `pending.sub` through a signed type-tagged cookie, user-supplied passkey names escaped by `renderEmail`. Two notes I would raise separately rather than change here:

- `PasskeyService.ts:319` — `expectedChallenge` is parsed out of the client's own `clientDataJSON`, which makes the library's challenge check compare a value to itself. Safe today because `consumeChallenge` independently requires the challenge to exist server-side and burns it, and because the signature covers `clientDataJSON` — but the library check is contributing nothing, so there is no second line of defense if `consumeChallenge` ever loosens. Returning the stored row's challenge and passing that would restore it.
- `PasskeyService.ts:337` — a non-increasing `signCount` is the spec's cloned-authenticator signal; it is logged and then authenticated anyway, and the lower counter is written back, which resets the baseline. The synced-passkey exemption (`prev > 0 && newCounter > 0`) is correct; only the response to detection is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
