### PR TITLE
Revert Blacksmith runner migration to unblock CI and production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -36,15 +36,16 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - uses: docker/setup-buildx-action@v3
 
       # Image expects context ./dist from the Build step above (Sentry inject is deploy-only).
       - name: Build container image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false
           tags: ghcr.io/t21c/tuf-backend:ci
           build-args: |
             GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
@@ -60,8 +60,7 @@ jobs:
           sourcemaps: ./dist
           inject: true
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -71,7 +70,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push immutable image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -79,6 +78,8 @@ jobs:
           labels: org.opencontainers.image.revision=${{ github.sha }}
           build-args: |
             GIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Connect to Tailscale
         if: ${{ vars.PRODUCTION_DEPLOY_ENABLED == 'true' }}

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   promote:
     environment: production
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Validate immutable tag
         env:


### PR DESCRIPTION
Master CI and the production deploy are both stuck in `Waiting for a runner to pick up this job...` after #16. No Blacksmith runner is claiming jobs for this org, so every job requesting `blacksmith-4vcpu-ubuntu-2404` queues indefinitely:

- Runs [30731395413](https://github.com/T21C/tuf-backend/actions/runs/30731395413) (`validate`) and [30731395410](https://github.com/T21C/tuf-backend/actions/runs/30731395410) (`deploy`) sit at `status: queued` with an empty `runner_name`.
- The migration's own PR run [30731262807](https://github.com/T21C/tuf-backend/actions/runs/30731262807) never started either: queued 6 minutes, `runner_name: ""`, then cancelled.
- Blacksmith reports 0 jobs and 0 billed minutes for the org over the last 30 days, i.e. nothing has ever been picked up.

The label itself is valid (`blacksmith-4vcpu-ubuntu-2404` is in the runner catalog), so this is an account/runner-allocation issue on the Blacksmith side, not a workflow bug.

This is a straight `git revert` of the migration commit, restoring GitHub-hosted runners and the stock Docker actions across all three workflows:

```yaml
jobs:
  validate:
    runs-on: ubuntu-latest
    # ...
      - uses: docker/setup-buildx-action@v3
      - name: Build container image
        uses: docker/build-push-action@v6
        with:
          cache-from: type=gha
          cache-to: type=gha,mode=max
```

The Blacksmith-specific actions (`useblacksmith/setup-docker-builder`, `useblacksmith/build-push-action`) have to come back out together with the labels, since they only run on Blacksmith runners.

Merge this only if you want CI unblocked right now. If the runner allocation can be fixed on the Blacksmith side (enabling this repo for runners in the dashboard at app.blacksmith.sh), the better move is to leave #16 in place, re-run the two stuck runs, and close this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/T21C/codesmith/tuf-backend/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->