### PR TITLE
Add rate limiting and caching for historical leaderboard bounds endpoint

### DIFF
--- a/src/database/migrations/1785761555_plre_scoring_version_day_index.cjs
+++ b/src/database/migrations/1785761555_plre_scoring_version_day_index.cjs
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Covering index for historical leaderboard reconstruction:
+ *   WHERE scoringVersion = ? AND effectiveDay <= ?
+ *   GROUP BY playerId / MAX(effectiveDay)
+ *
+ * Existing unique index is (scoringVersion, playerId, effectiveDay) which is
+ * optimized for per-player lookups, not date-range board rebuilds.
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    const indexes = await queryInterface.showIndex('player_leaderboard_rank_events');
+    const names = new Set(indexes.map((idx) => idx.name));
+
+    if (!names.has('idx_plre_version_day_player')) {
+      await queryInterface.addIndex(
+        'player_leaderboard_rank_events',
+        ['scoringVersion', 'effectiveDay', 'playerId'],
+        { name: 'idx_plre_version_day_player' },
+      );
+    }
+  },
+
+  async down(queryInterface) {
+    const indexes = await queryInterface.showIndex('player_leaderboard_rank_events');
+    const names = new Set(indexes.map((idx) => idx.name));
+
+    if (names.has('idx_plre_version_day_player')) {
+      await queryInterface.removeIndex(
+        'player_leaderboard_rank_events',
+        'idx_plre_version_day_player',
+      );
+    }
+  },
+};

--- a/src/server/routes/v3/players.ts
+++ b/src/server/routes/v3/players.ts
@@ -22,13 +22,15 @@ import { logger } from '@/server/services/core/LoggerService.js';
 import { PaginationQuery } from '@/server/interfaces/models/index.js';
 import Player from '@/models/players/Player.js';
 import PlayerAlias from '@/models/players/PlayerAlias.js';
-import { CacheInvalidation } from '@/server/middleware/cache.js';
+import { Cache, CacheInvalidation } from '@/server/middleware/cache.js';
+import { createRateLimiter } from '@/server/decorators/rateLimiter.js';
 import { normalizeTufStellarIconVariant } from '@/misc/utils/subscriptions/tufStellarSubscription.js';
 import { isTufStellarFeatureEnabled } from '@/config/app.config.js';
 import { DEFAULT_LEADERBOARD_RANK_SCORING_VERSION, RANK_HISTORY_MAX_POINTS } from '@/config/leaderboardRankHistory.js';
 import { buildRankHistorySeries } from '@/server/services/leaderboard/rankHistorySeries.js';
 import {
   fetchHistoricalLeaderboardAtDate,
+  fetchHistoricalLeaderboardBounds,
   hydrateHistoricalLeaderboardPlayers,
   type HistoricalLeaderboardMetric,
 } from '@/server/services/leaderboard/historicalLeaderboardAtDate.js';
@@ -63,6 +65,15 @@ const playerStatsService = PlayerStatsService.getInstance();
 
 const DEFAULT_LIMIT = 30;
 const MAX_LIMIT = 100;
+
+/** Public endpoint; cheap to spam and each miss is a multi-second board rebuild. */
+const leaderboardHistoryLimiter = createRateLimiter({
+  type: 'leaderboard_history',
+  windowMs: 60 * 1000,
+  maxAttempts: 40,
+  blockDuration: 2 * 60 * 1000,
+  failClosed: false,
+});
 
 function parseLimit(raw: unknown, fallback = DEFAULT_LIMIT): number {
   const n = parseInt(String(raw ?? ''), 10);
@@ -263,6 +274,53 @@ router.get(
 );
 
 /**
+ * Lightweight date bounds for the past-leaderboard UI (no board rebuild).
+ */
+router.get(
+  '/leaderboard-history/bounds',
+  leaderboardHistoryLimiter.middleware,
+  Cache({
+    ttl: 300,
+    prefix: 'v3:players:leaderboard-history-bounds',
+    varyByQuery: ['scoringVersion'],
+    tags: ['leaderboard-history'],
+  }),
+  ApiDoc({
+    operationId: 'v3GetLeaderboardHistoryBounds',
+    summary: 'Historical leaderboard date bounds (v3)',
+    description:
+      'Returns min/max selectable UTC dates for past leaderboard without reconstructing a board. Prefer this over probing `/leaderboard-history` with a dummy date.',
+    tags: ['Database', 'Leaderboard', 'v3'],
+    query: {
+      scoringVersion: { schema: { type: 'string' } },
+    },
+    responses: {
+      200: { description: 'Date bounds' },
+      429: { description: 'Rate limited' },
+      ...standardErrorResponses500,
+    },
+  }),
+  async (req: Request, res: Response) => {
+    try {
+      const scoringVersion =
+        String(req.query.scoringVersion ?? '').trim() || DEFAULT_LEADERBOARD_RANK_SCORING_VERSION;
+      const bounds = await fetchHistoricalLeaderboardBounds(scoringVersion);
+      return res.json({
+        minDate: bounds.minDate,
+        maxDate: bounds.maxDate,
+        scoringVersion,
+      });
+    } catch (error) {
+      logger.error('[v3 /players/leaderboard-history/bounds] failure', error);
+      return res.status(500).json({
+        error: 'Failed to fetch historical leaderboard bounds',
+        details: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+);
+
+/**
  * Rank-only leaderboard reconstructed at a past UTC date from player_leaderboard_rank_events.
  *
  * Query params: date (YYYY-MM-DD), metric (rankedScore|generalScore), order (asc|desc),
@@ -270,11 +328,19 @@ router.get(
  */
 router.get(
   '/leaderboard-history',
+  leaderboardHistoryLimiter.middleware,
+  Cache({
+    // Past days are immutable once snapshotted; short TTL still refreshes avatar/name hydration.
+    ttl: 120,
+    prefix: 'v3:players:leaderboard-history',
+    varyByQuery: ['date', 'metric', 'order', 'query', 'offset', 'limit', 'scoringVersion'],
+    tags: ['leaderboard-history'],
+  }),
   ApiDoc({
     operationId: 'v3GetLeaderboardHistory',
     summary: 'Historical player leaderboard (v3)',
     description:
-      'Rank-only leaderboard as of end-of-day `date` (UTC), reconstructed by forward-filling `player_leaderboard_rank_events`. Hydrates current player names/avatars from Elasticsearch. Supports metric (rankedScore|generalScore), order, name query, and pagination. Newest selectable date is yesterday.',
+      'Rank-only leaderboard as of end-of-day `date` (UTC), reconstructed by forward-filling `player_leaderboard_rank_events`. Hydrates current player names/avatars from Elasticsearch. Supports metric (rankedScore|generalScore), order, name query, and pagination. Newest selectable date is yesterday. Rate-limited per IP.',
     tags: ['Database', 'Leaderboard', 'v3'],
     query: {
       date: { schema: { type: 'string' } },
@@ -288,6 +354,7 @@ router.get(
     responses: {
       200: { description: 'Historical leaderboard results' },
       400: { schema: errorResponseSchema },
+      429: { description: 'Rate limited' },
       ...standardErrorResponses500,
     },
   }),

--- a/src/server/services/leaderboard/historicalLeaderboardAtDate.ts
+++ b/src/server/services/leaderboard/historicalLeaderboardAtDate.ts
@@ -31,6 +31,12 @@ export interface HistoricalLeaderboardResult {
   maxDate: string | null;
 }
 
+const BOUNDS_CACHE_TTL_MS = 5 * 60 * 1000;
+const boundsCache = new Map<
+  string,
+  { value: HistoricalLeaderboardBounds; expiresAt: number }
+>();
+
 function toIsoDateOnly(raw: string | Date | null | undefined): string | null {
   if (raw == null) return null;
   if (raw instanceof Date) return utcDateOnlyFromDate(raw);
@@ -44,10 +50,16 @@ function metricRankColumn(metric: HistoricalLeaderboardMetric): 'rankedScoreRank
 /**
  * Available date range for historical leaderboard (UTC DATEONLY).
  * `maxDate` is capped at yesterday (last completed daily snapshot).
+ * Result is memoized briefly — bounds only change after the daily snapshot cron.
  */
 export async function fetchHistoricalLeaderboardBounds(
   scoringVersion: string = DEFAULT_LEADERBOARD_RANK_SCORING_VERSION,
 ): Promise<HistoricalLeaderboardBounds> {
+  const cached = boundsCache.get(scoringVersion);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
   const rows = (await sequelize.query(
     `SELECT MIN(effectiveDay) AS minDate, MAX(effectiveDay) AS maxDate
      FROM player_leaderboard_rank_events
@@ -66,10 +78,14 @@ export async function fetchHistoricalLeaderboardBounds(
     maxDate = yesterday;
   }
   if (minDate && maxDate && minDate > maxDate) {
-    return { minDate: null, maxDate: null };
+    const empty = { minDate: null, maxDate: null };
+    boundsCache.set(scoringVersion, { value: empty, expiresAt: Date.now() + BOUNDS_CACHE_TTL_MS });
+    return empty;
   }
 
-  return { minDate, maxDate };
+  const value = { minDate, maxDate };
+  boundsCache.set(scoringVersion, { value, expiresAt: Date.now() + BOUNDS_CACHE_TTL_MS });
+  return value;
 }
 
 /**
@@ -117,10 +133,11 @@ export async function fetchHistoricalLeaderboardAtDate(options: {
       WHERE scoringVersion = :scoringVersion
         AND effectiveDay <= :date
       GROUP BY playerId
-    ) latest ON latest.playerId = e.playerId AND latest.maxDay = e.effectiveDay
+    ) latest ON latest.playerId = e.playerId
+      AND latest.maxDay = e.effectiveDay
+      AND e.scoringVersion = :scoringVersion
     ${nameJoin}
-    WHERE e.scoringVersion = :scoringVersion
-      AND e.${rankCol} != :offBoard
+    WHERE e.${rankCol} != :offBoard
   `;
 
   const replacements: Record<string, unknown> = {


### PR DESCRIPTION
- Introduced a new endpoint `/leaderboard-history/bounds` to fetch lightweight date bounds for the historical leaderboard without rebuilding the board.
- Implemented rate limiting to prevent abuse, allowing a maximum of 40 attempts per minute.
- Added caching for the date bounds to improve performance, with a TTL of 5 minutes.
- Updated the existing `/leaderboard-history` endpoint to include rate limiting and caching as well, enhancing overall API efficiency.