### PR TITLE
Enhance song submission handling with verification state support

### DIFF
--- a/src/server/routes/v2/admin/submissions-song-artist.ts
+++ b/src/server/routes/v2/admin/submissions-song-artist.ts
@@ -661,11 +661,11 @@ router.post(
   ApiDoc({
     operationId: 'postAdminLevelSubmissionSongs',
     summary: 'Create and assign song',
-    description: 'Create or find song and assign to submission. Body: name, aliases?, songRequestId?. Super admin.',
+    description: 'Create or find song and assign to submission. Body: name, aliases?, songRequestId?, verificationState?. Super admin.',
     tags: ['Admin', 'Submissions'],
     security: ['bearerAuth'],
     params: { id: stringIdParamSpec },
-    requestBody: { description: 'name, aliases, songRequestId', schema: { type: 'object', properties: { name: { type: 'string' }, aliases: { type: 'array', items: { type: 'string' } }, songRequestId: { type: 'number' } }, required: ['name'] }, required: true },
+    requestBody: { description: 'name, aliases, songRequestId, verificationState', schema: { type: 'object', properties: { name: { type: 'string' }, aliases: { type: 'array', items: { type: 'string' } }, songRequestId: { type: 'number' }, verificationState: { type: 'string' } }, required: ['name'] }, required: true },
     responses: { 200: { description: 'Updated submission' }, ...standardErrorResponses },
   }),
   async (req: Request, res: Response) => {
@@ -673,7 +673,7 @@ router.post(
   try {
     transaction = await sequelize.transaction();
     const { id } = req.params;
-    const { name, aliases, songRequestId } = req.body;
+    const { name, aliases, songRequestId, verificationState: bodyVerificationState } = req.body;
 
     if (!name) {
       await safeTransactionRollback(transaction);
@@ -700,6 +700,12 @@ router.post(
       return res.status(404).json({ error: 'Submission not found' });
     }
 
+    // Prefer explicit body state, then existing song request state, then pending
+    const verificationState =
+      (typeof bodyVerificationState === 'string' && bodyVerificationState.trim()) ||
+      submission.songRequest?.verificationState ||
+      'pending';
+
     // Create or find song: same title only reuses a row when credit artist set matches submission artists
     const resolvedArtistIds =
       await artistService.resolveArtistIdsFromLevelSubmissionArtistRequests(submission);
@@ -717,7 +723,7 @@ router.post(
         song = await Song.create(
           {
             name: trimmedName,
-            verificationState: 'pending',
+            verificationState: verificationState,
           },
           { transaction }
         );
@@ -727,7 +733,7 @@ router.post(
         where: { name: trimmedName },
         defaults: {
           name: trimmedName,
-          verificationState: 'pending',
+          verificationState: verificationState,
         },
         transaction,
       });
@@ -753,7 +759,7 @@ router.post(
         songId: song.id,
         songName: song.name,
         isNewRequest: false,
-        verificationState: 'pending'
+        verificationState: verificationState,
       }, { transaction });
     } else if (!submission.songRequest) {
       // Create new song request if doesn't exist
@@ -762,7 +768,7 @@ router.post(
         songId: song.id,
         songName: song.name,
         isNewRequest: false,
-        verificationState: 'pending'
+        verificationState: verificationState,
       }, { transaction });
     }
 

--- a/src/server/routes/v2/misc/form/level/dto.ts
+++ b/src/server/routes/v2/misc/form/level/dto.ts
@@ -10,6 +10,21 @@ import type { CreatorRequestLike, TeamRequestLike } from '../shared/validators.j
  * Shape of the normalised level submission payload that both `/validate` and
  * `/submit` work against. Producing this is pure: no DB, no I/O.
  */
+const SONG_VERIFICATION_STATES = new Set([
+  'declined',
+  'pending',
+  'conditional',
+  'ysmod_only',
+  'allowed',
+  'tuf_verified',
+]);
+
+function parseSongVerificationState(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return SONG_VERIFICATION_STATES.has(trimmed) ? trimmed : null;
+}
+
 export interface LevelFormSanitised {
   artist: string;
   song: string;
@@ -21,6 +36,8 @@ export interface LevelFormSanitised {
   songId: number | null;
   artistId: number | null;
   isNewSongRequest: boolean;
+  /** Claimed verification for a new song request; null when linking an existing song. */
+  songVerificationState: string | null;
   isNewArtistRequest: boolean;
   creatorRequests: CreatorRequestLike[];
   teamRequest: TeamRequestLike | null;
@@ -86,6 +103,9 @@ export function parseAndSanitizeLevelForm(body: Record<string, unknown>): Parsed
   const isNewArtistRequest = asBool(body.isNewArtistRequest);
   const songId = isNewSongRequest ? null : parsePositiveIntOrNull(body.songId);
   const artistId = isNewArtistRequest ? null : parsePositiveIntOrNull(body.artistId);
+  const songVerificationState = isNewSongRequest
+    ? parseSongVerificationState(body.songVerificationState) || 'pending'
+    : null;
 
   const creatorRequestsRaw = safeParseJSON<unknown>(body.creatorRequests as string | object | null | undefined);
   const creatorRequests: CreatorRequestLike[] = Array.isArray(creatorRequestsRaw)
@@ -140,6 +160,7 @@ export function parseAndSanitizeLevelForm(body: Record<string, unknown>): Parsed
     songId,
     artistId,
     isNewSongRequest,
+    songVerificationState,
     isNewArtistRequest,
     creatorRequests,
     teamRequest,

--- a/src/server/routes/v2/misc/form/level/selectLevelRoute.ts
+++ b/src/server/routes/v2/misc/form/level/selectLevelRoute.ts
@@ -1,6 +1,7 @@
 import express, { Router, type Request, type Response } from 'express';
 
 import LevelSubmission from '@/models/submissions/LevelSubmission.js';
+import LevelSubmissionSongRequest from '@/models/submissions/LevelSubmissionSongRequest.js';
 import Song from '@/models/songs/Song.js';
 import cdnService, { CdnError } from '@/server/services/core/CdnService.js';
 import { isYsmodOnlyState } from '@/server/submissions/submissionEvidenceRules.js';
@@ -75,6 +76,14 @@ router.post(
           userId: req.user?.id,
           status: 'pending',
         },
+        include: [
+          {
+            model: LevelSubmissionSongRequest,
+            as: 'songRequest',
+            attributes: ['verificationState'],
+            required: false,
+          },
+        ],
       });
 
       if (!submission) {
@@ -123,9 +132,15 @@ router.post(
         });
       }
 
-      if (submission.songId != null && !selectedFile.hasYouTubeStream) {
-        const song = await Song.findByPk(submission.songId, { attributes: ['verificationState'] });
-        if (isYsmodOnlyState(song?.verificationState)) {
+      if (!selectedFile.hasYouTubeStream) {
+        let songVerificationState: string | null | undefined;
+        if (submission.songId != null) {
+          const song = await Song.findByPk(submission.songId, { attributes: ['verificationState'] });
+          songVerificationState = song?.verificationState;
+        } else {
+          songVerificationState = submission.songRequest?.verificationState;
+        }
+        if (isYsmodOnlyState(songVerificationState)) {
           return res.status(400).json({
             success: false,
             error: 'This song is YSMod-only: the selected chart must require the YouTubeStream mod',

--- a/src/server/routes/v2/misc/form/level/submissionService.ts
+++ b/src/server/routes/v2/misc/form/level/submissionService.ts
@@ -135,6 +135,8 @@ export async function createLevelSubmission(
           transaction: preTx,
         });
         songRequiresYsModFlag = isYsmodOnlyState(song?.verificationState);
+      } else if (sanitized.isNewSongRequest) {
+        songRequiresYsModFlag = isYsmodOnlyState(sanitized.songVerificationState);
       }
       await assertNoDuplicateLevelSubmission(sanitized, userId, preTx);
       const evidence = await computeEvidenceRequirements(sanitized, preTx);
@@ -378,6 +380,9 @@ async function createSubmissionRows(args: {
         songId: sanitized.songId,
         songName: sanitized.isNewSongRequest ? sanitized.song : null,
         isNewRequest: sanitized.isNewSongRequest,
+        verificationState: sanitized.isNewSongRequest
+          ? ((sanitized.songVerificationState as Song['verificationState'] | null) || 'pending')
+          : null,
       },
       { transaction },
     );


### PR DESCRIPTION
- Updated the API documentation and request body to include `verificationState` for song submissions.
- Modified the submission processing logic to handle the new `verificationState` field, allowing for more accurate state management.
- Introduced a new utility function to parse and validate song verification states.
- Adjusted the level form sanitization to accommodate the new verification state, ensuring proper handling for new song requests.
- Enhanced the submission service to utilize the verification state when creating new song requests.