### PR TITLE
proxy CDN images through CORS-enabled service

### DIFF
--- a/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.test.ts
+++ b/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { Readable, Writable } from 'node:stream';
+import test from 'node:test';
+import type { Response } from 'express';
+
+import { streamStorageObjectResponse } from './streamStorageObjectResponse.js';
+
+class ResponseSink extends Writable {
+    readonly chunks: Buffer[] = [];
+    readonly headers = new Map<string, string | number | readonly string[]>();
+
+    setHeader(name: string, value: string | number | readonly string[]): this {
+        this.headers.set(name.toLowerCase(), value);
+        return this;
+    }
+
+    override _write(
+        chunk: Buffer | string,
+        _encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+    ): void {
+        this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        callback();
+    }
+}
+
+void test('storage image response streams bytes without redirecting to the public bucket', async () => {
+    const response = new ResponseSink();
+    const requestedPaths: string[] = [];
+
+    await streamStorageObjectResponse(response as unknown as Response, {
+        storagePath: 'images/difficulty_icon/file-id/original.png',
+        contentType: 'image/png',
+        cacheControl: 'public, max-age=31536000, immutable',
+        openStream: async storagePath => {
+            requestedPaths.push(storagePath);
+            return Readable.from([Buffer.from('image-bytes')]);
+        },
+    });
+
+    assert.deepEqual(requestedPaths, ['images/difficulty_icon/file-id/original.png']);
+    assert.equal(Buffer.concat(response.chunks).toString(), 'image-bytes');
+    assert.equal(response.headers.get('content-type'), 'image/png');
+    assert.equal(response.headers.get('cache-control'), 'public, max-age=31536000, immutable');
+    assert.equal(response.headers.has('location'), false);
+});

--- a/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.ts
+++ b/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.ts
@@ -1,0 +1,27 @@
+import type { Response } from 'express';
+import { pipeline } from 'node:stream/promises';
+
+export interface StorageObjectStreamResponseOptions {
+    storagePath: string;
+    contentType: string;
+    cacheControl: string;
+    openStream: (storagePath: string) => Promise<NodeJS.ReadableStream>;
+}
+
+/**
+ * Proxy a small public storage object through the CDN service.
+ *
+ * The browser-visible response then receives the CDN service's CORS headers
+ * instead of depending on CORS headers attached to a cached R2 custom-domain
+ * object. Large downloads should keep using direct object-storage redirects.
+ */
+export async function streamStorageObjectResponse(
+    res: Response,
+    options: StorageObjectStreamResponseOptions,
+): Promise<void> {
+    const stream = await options.openStream(options.storagePath);
+
+    res.setHeader('Content-Type', options.contentType);
+    res.setHeader('Cache-Control', options.cacheControl);
+    await pipeline(stream, res);
+}

--- a/src/externalServices/cdnService/routes/general.ts
+++ b/src/externalServices/cdnService/routes/general.ts
@@ -1,11 +1,14 @@
 import { Router, Request, Response } from 'express';
 import { logger } from '@/server/services/core/LoggerService.js';
 import CdnFile from '@/models/cdn/CdnFile.js';
-import { CDN_CONFIG, IMAGE_TYPES, MIME_TYPES } from '@/externalServices/cdnService/config.js';
+import { CDN_CONFIG, IMAGE_TYPES } from '@/externalServices/cdnService/config.js';
 import { spacesStorage } from '@/externalServices/cdnService/infra/storage/spacesStorage.js';
 import { getSequelizeForModelGroup } from '@/config/db.js';
 import { Transaction } from 'sequelize';
 import axios from 'axios';
+import path from 'path';
+import { mimeTypeForImageExtension } from '@/externalServices/cdnService/services/imageProcessor.js';
+import { streamStorageObjectResponse } from '@/externalServices/cdnService/http/responses/streamStorageObjectResponse.js';
 
 const cdnSequelize = getSequelizeForModelGroup('cdn');
 import { safeTransactionRollback } from '@/misc/utils/Utility.js';
@@ -198,7 +201,7 @@ router.get('/:fileId', async (req: Request, res: Response) => {
             return handleZipRequest(req, res, file);
         }
 
-        // Handle image types - redirect to proper image endpoint or serve original
+        // Handle image types by proxying the original through this CORS-enabled service.
         if (IMAGE_TYPES[file.type as keyof typeof IMAGE_TYPES]) {
             const imageMetadata = (file.metadata || {}) as any;
             const originalVariant = imageMetadata?.variants?.original;
@@ -207,10 +210,13 @@ router.get('/:fileId', async (req: Request, res: Response) => {
                 if (!imageExists) {
                     return res.status(404).json({ error: 'File not found' });
                 }
-                const url = await spacesStorage.getPresignedUrl(originalVariant.path);
-                // Cache the redirect itself aggressively since the target URL is immutable.
-                res.setHeader('Cache-Control', CDN_CONFIG.cacheControl);
-                return res.redirect(301, url);
+                await streamStorageObjectResponse(res, {
+                    storagePath: originalVariant.path,
+                    contentType: mimeTypeForImageExtension(path.extname(originalVariant.path)),
+                    cacheControl: CDN_CONFIG.cacheControl,
+                    openStream: storagePath => spacesStorage.getFileStream(storagePath),
+                });
+                return;
             }
         }
 
@@ -289,7 +295,7 @@ router.delete('/:fileId', async (req: Request, res: Response) => {
                     fileType,
                     timestamp: new Date().toISOString()
                 });
-            } 
+            }
             else {
                 if (IMAGE_TYPES[fileType as keyof typeof IMAGE_TYPES]) {
                     const imageTypeConfig = IMAGE_TYPES[fileType as keyof typeof IMAGE_TYPES];

--- a/src/externalServices/cdnService/routes/images.ts
+++ b/src/externalServices/cdnService/routes/images.ts
@@ -7,6 +7,8 @@ import fs from 'fs';
 import path from 'path';
 import { cdnLocalTemp } from '@/externalServices/cdnService/infra/workspaces/cdnLocalTempManager.js';
 import { spacesStorage } from '@/externalServices/cdnService/infra/storage/spacesStorage.js';
+import { mimeTypeForImageExtension } from '@/externalServices/cdnService/services/imageProcessor.js';
+import { streamStorageObjectResponse } from '@/externalServices/cdnService/http/responses/streamStorageObjectResponse.js';
 
 /**
  * Image routes: sync processing today. If you add async / 202 + `X-Upload-Id` (or another job id),
@@ -61,16 +63,12 @@ router.get('/:type/:fileId/:size', async (req: Request, res: Response) => {
                 return res.status(404).json({ error: 'Image file not found' });
             }
 
-            if (fileExists) {
-                const url = await spacesStorage.getPresignedUrl(variantRef.path);
-                // Cache the redirect itself aggressively since the target URL is immutable.
-                res.setHeader('Cache-Control', CDN_CONFIG.cacheControl);
-                return res.redirect(301, url);
-            }
-
-            res.setHeader('Content-Type', MIME_TYPES[file.type as ImageType]);
-            res.setHeader('Cache-Control', CDN_CONFIG.cacheControl);
-            fs.createReadStream(variantRef.path).pipe(res);
+            await streamStorageObjectResponse(res, {
+                storagePath: variantRef.path,
+                contentType: mimeTypeForImageExtension(path.extname(variantRef.path)),
+                cacheControl: CDN_CONFIG.cacheControl,
+                openStream: storagePath => spacesStorage.getFileStream(storagePath),
+            });
             return;
         }
 
@@ -98,7 +96,9 @@ router.get('/:type/:fileId/:size', async (req: Request, res: Response) => {
         fs.createReadStream(fsPath).pipe(res);
     } catch (error) {
         logger.error('Image delivery error:', error);
-        res.status(500).json({ error: 'Image delivery failed' });
+        if (!res.headersSent) {
+            res.status(500).json({ error: 'Image delivery failed' });
+        }
     }
     return;
 });


### PR DESCRIPTION
## Summary
- serve storage-backed image variants through the CDN service instead of redirecting browsers to the public object domain
- preserve image content types and immutable cache headers while streaming responses
- keep large ZIP downloads on direct storage redirects
- add a regression test covering streamed bytes, response headers, and the absence of a redirect

## Root cause
Asset downloads started at `api.tuforums.com` and were redirected to `cdn.tuforums.com`. The final object response did not include `Access-Control-Allow-Origin`, so fetch-based downloads were blocked even though the initial API response had CORS headers.

## Validation
- `npm run build`
- `npm test` (9 tests passed)
- security lint
- strict lint on changed files
- `git diff --check`
