### PR TITLE
add client abort error handling in streaming responses

### DIFF
--- a/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.test.ts
+++ b/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.test.ts
@@ -3,7 +3,7 @@ import { Readable, Writable } from 'node:stream';
 import test from 'node:test';
 import type { Response } from 'express';
 
-import { streamStorageObjectResponse } from './streamStorageObjectResponse.js';
+import { isClientAbortError, streamStorageObjectResponse } from './streamStorageObjectResponse.js';
 
 class ResponseSink extends Writable {
     readonly chunks: Buffer[] = [];
@@ -43,4 +43,27 @@ void test('storage image response streams bytes without redirecting to the publi
     assert.equal(response.headers.get('content-type'), 'image/png');
     assert.equal(response.headers.get('cache-control'), 'public, max-age=31536000, immutable');
     assert.equal(response.headers.has('location'), false);
+});
+
+void test('client abort during stream is ignored', async () => {
+    const response = new ResponseSink();
+    response.destroy();
+
+    await streamStorageObjectResponse(response as unknown as Response, {
+        storagePath: 'images/difficulty_icon/file-id/original.png',
+        contentType: 'image/png',
+        cacheControl: 'public, max-age=31536000, immutable',
+        openStream: async () => Readable.from([Buffer.from('image-bytes')]),
+    });
+});
+
+void test('isClientAbortError matches stream close codes', () => {
+    assert.equal(isClientAbortError(Object.assign(new Error('Premature close'), {
+        code: 'ERR_STREAM_PREMATURE_CLOSE',
+    })), true);
+    assert.equal(isClientAbortError(Object.assign(new Error('Cannot pipe'), {
+        code: 'ERR_STREAM_UNABLE_TO_PIPE',
+    })), true);
+    assert.equal(isClientAbortError(Object.assign(new Error('aborted'), { name: 'AbortError' })), true);
+    assert.equal(isClientAbortError(new Error('R2 timeout')), false);
 });

--- a/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.ts
+++ b/src/externalServices/cdnService/http/responses/streamStorageObjectResponse.ts
@@ -8,6 +8,24 @@ export interface StorageObjectStreamResponseOptions {
     openStream: (storagePath: string) => Promise<NodeJS.ReadableStream>;
 }
 
+export function isClientAbortError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const err = error as { code?: string; name?: string; message?: string };
+    if (err.name === 'AbortError') {
+        return true;
+    }
+
+    return err.code === 'ERR_STREAM_PREMATURE_CLOSE'
+        || err.code === 'ERR_STREAM_DESTROYED'
+        || err.code === 'ERR_STREAM_UNABLE_TO_PIPE'
+        || err.code === 'ECONNRESET'
+        || err.code === 'EPIPE'
+        || err.code === 'ECANCELED';
+}
+
 /**
  * Proxy a small public storage object through the CDN service.
  *
@@ -23,5 +41,13 @@ export async function streamStorageObjectResponse(
 
     res.setHeader('Content-Type', options.contentType);
     res.setHeader('Cache-Control', options.cacheControl);
-    await pipeline(stream, res);
+
+    try {
+        await pipeline(stream, res);
+    } catch (error) {
+        if (isClientAbortError(error)) {
+            return;
+        }
+        throw error;
+    }
 }

--- a/src/externalServices/cdnService/routes/general.ts
+++ b/src/externalServices/cdnService/routes/general.ts
@@ -8,7 +8,10 @@ import { Transaction } from 'sequelize';
 import axios from 'axios';
 import path from 'path';
 import { mimeTypeForImageExtension } from '@/externalServices/cdnService/services/imageProcessor.js';
-import { streamStorageObjectResponse } from '@/externalServices/cdnService/http/responses/streamStorageObjectResponse.js';
+import {
+    isClientAbortError,
+    streamStorageObjectResponse,
+} from '@/externalServices/cdnService/http/responses/streamStorageObjectResponse.js';
 
 const cdnSequelize = getSequelizeForModelGroup('cdn');
 import { safeTransactionRollback } from '@/misc/utils/Utility.js';
@@ -222,6 +225,9 @@ router.get('/:fileId', async (req: Request, res: Response) => {
 
         await file.increment('accessCount');
     } catch (error) {
+        if (isClientAbortError(error)) {
+            return;
+        }
         logger.error('File delivery error:', {
             error: error instanceof Error ? error.message : String(error),
             stack: error instanceof Error ? error.stack : undefined

--- a/src/externalServices/cdnService/routes/images.ts
+++ b/src/externalServices/cdnService/routes/images.ts
@@ -2,13 +2,17 @@ import { logger } from '@/server/services/core/LoggerService.js';
 import imageFactory, { ImageProcessingError } from '@/externalServices/cdnService/services/imageFactory.js';
 import { CDN_CONFIG, IMAGE_TYPES, ImageType, ImageSize, MIME_TYPES } from '@/externalServices/cdnService/config.js';
 import { Request, Response, Router } from 'express';
+import { pipeline } from 'node:stream/promises';
 import CdnFile from '@/models/cdn/CdnFile.js';
 import fs from 'fs';
 import path from 'path';
 import { cdnLocalTemp } from '@/externalServices/cdnService/infra/workspaces/cdnLocalTempManager.js';
 import { spacesStorage } from '@/externalServices/cdnService/infra/storage/spacesStorage.js';
 import { mimeTypeForImageExtension } from '@/externalServices/cdnService/services/imageProcessor.js';
-import { streamStorageObjectResponse } from '@/externalServices/cdnService/http/responses/streamStorageObjectResponse.js';
+import {
+    isClientAbortError,
+    streamStorageObjectResponse,
+} from '@/externalServices/cdnService/http/responses/streamStorageObjectResponse.js';
 
 /**
  * Image routes: sync processing today. If you add async / 202 + `X-Upload-Id` (or another job id),
@@ -79,22 +83,20 @@ router.get('/:type/:fileId/:size', async (req: Request, res: Response) => {
             return res.status(404).json({ error: 'Image file not found' });
         }
 
-        // Log access
-        /* 500 mb is not fun data to manage
-        await FileAccessLog.create({
-            fileId: file.id,
-            ipAddress: req.ip || req.headers['x-forwarded-for'] || null,
-            userAgent: req.get('user-agent') || null
-        });
-        */
-
-        // also useless
-        //await file.increment('accessCount');
-
         res.setHeader('Content-Type', MIME_TYPES[file.type as ImageType]);
         res.setHeader('Cache-Control', CDN_CONFIG.cacheControl);
-        fs.createReadStream(fsPath).pipe(res);
+        try {
+            await pipeline(fs.createReadStream(fsPath), res);
+        } catch (error) {
+            if (isClientAbortError(error)) {
+                return;
+            }
+            throw error;
+        }
     } catch (error) {
+        if (isClientAbortError(error)) {
+            return;
+        }
         logger.error('Image delivery error:', error);
         if (!res.headersSent) {
             res.status(500).json({ error: 'Image delivery failed' });

--- a/src/externalServices/thumbnailWorker/app.ts
+++ b/src/externalServices/thumbnailWorker/app.ts
@@ -35,6 +35,9 @@ const worker = new Worker<ThumbnailRenderJobData, ThumbnailRenderJobResult>(
     connection: createBullMqConnection(),
     prefix: THUMBNAIL_WORKER_CONFIG.queuePrefix,
     concurrency: THUMBNAIL_WORKER_CONFIG.concurrency,
+    lockDuration: THUMBNAIL_WORKER_CONFIG.jobLockMs,
+    stalledInterval: Math.max(5_000, Math.floor(THUMBNAIL_WORKER_CONFIG.jobLockMs / 4)),
+    maxStalledCount: 1,
     autorun: false,
   },
 );

--- a/src/externalServices/thumbnailWorker/config.ts
+++ b/src/externalServices/thumbnailWorker/config.ts
@@ -47,6 +47,10 @@ export const THUMBNAIL_WORKER_CONFIG = Object.freeze({
   maxWaitingJobs: positiveInteger('THUMBNAIL_QUEUE_MAX_WAITING', 20),
   requestWaitMs: positiveInteger('THUMBNAIL_REQUEST_WAIT_MS', 5000),
   ogRequestWaitMs: positiveInteger('THUMBNAIL_OG_REQUEST_WAIT_MS', 15000),
+  // How long the in-flight API task waits for this entity's PNG after enqueue.
+  // HTTP requests still return 204 after requestWaitMs / ogRequestWaitMs.
+  generationWaitMs: positiveInteger('THUMBNAIL_GENERATION_WAIT_MS', 600_000),
+  jobLockMs: positiveInteger('THUMBNAIL_JOB_LOCK_MS', 180_000),
   outputPollMs: positiveInteger('THUMBNAIL_OUTPUT_POLL_MS', 100),
   inputDirectory:
     process.env.THUMBNAIL_JOB_INPUT_PATH || path.join(cachePath, 'thumbnail-render-inputs'),

--- a/src/externalServices/thumbnailWorker/generationCoalesce.ts
+++ b/src/externalServices/thumbnailWorker/generationCoalesce.ts
@@ -1,0 +1,54 @@
+export class ThumbnailRenderPendingError extends Error {
+  constructor(readonly waitMs: number) {
+    super(`Thumbnail render is still processing after ${waitMs}ms`);
+    this.name = 'ThumbnailRenderPendingError';
+  }
+}
+
+const inFlightGenerations = new Map<string, Promise<Buffer>>();
+
+async function waitWithTimeout(promise: Promise<Buffer>, waitMs: number): Promise<Buffer> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<Buffer>((_, reject) => {
+        timer = setTimeout(() => reject(new ThumbnailRenderPendingError(waitMs)), waitMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Share one in-flight produce() across concurrent HTTP requests.
+ *
+ * The HTTP wait (`waitMs`) may expire with ThumbnailRenderPendingError while
+ * produce() keeps running. Callers must not start a second produce() for the
+ * same key — that is what turned renderer timeouts into a CPU stampede.
+ */
+export async function awaitThumbnailGeneration(options: {
+  key: string;
+  waitMs: number;
+  produce: () => Promise<Buffer>;
+}): Promise<Buffer> {
+  let generation = inFlightGenerations.get(options.key);
+  if (!generation) {
+    let current!: Promise<Buffer>;
+    current = Promise.resolve()
+      .then(() => options.produce())
+      .finally(() => {
+        if (inFlightGenerations.get(options.key) === current) {
+          inFlightGenerations.delete(options.key);
+        }
+      });
+    // Timed-out HTTP requests stop awaiting `current`. Keep a listener so a
+    // later produce() failure cannot become an unhandledRejection.
+    void current.catch(() => undefined);
+    inFlightGenerations.set(options.key, current);
+    generation = current;
+  }
+
+  return waitWithTimeout(generation, options.waitMs);
+}

--- a/src/externalServices/thumbnailWorker/producer.test.ts
+++ b/src/externalServices/thumbnailWorker/producer.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {isDuplicateJobIdError, shouldReuseExistingThumbnailJob} from './producerHelpers.js';
+
+test('in-flight and queued jobs are reused instead of re-enqueued', () => {
+  for (const state of ['waiting', 'delayed', 'active', 'paused', 'waiting-children', 'prioritized']) {
+    assert.equal(shouldReuseExistingThumbnailJob(state), true, state);
+  }
+});
+
+test('finished jobs are not reused when the output is missing', () => {
+  for (const state of ['completed', 'failed', 'unknown']) {
+    assert.equal(shouldReuseExistingThumbnailJob(state), false, state);
+  }
+});
+
+test('BullMQ duplicate jobId errors are treated as a race, not an outage', () => {
+  assert.equal(isDuplicateJobIdError(new Error('Job render_level_1_LARGE_png already exists')), true);
+  assert.equal(isDuplicateJobIdError(new Error('connection refused')), false);
+});

--- a/src/externalServices/thumbnailWorker/producer.ts
+++ b/src/externalServices/thumbnailWorker/producer.ts
@@ -3,7 +3,6 @@ import {type JobsOptions} from 'bullmq';
 import {
   addThumbnailRenderJob,
   getThumbnailRenderQueue,
-  thumbnailRenderJobId,
 } from './queue.js';
 import {
   assertSafeFileName,
@@ -12,13 +11,17 @@ import {
 } from './fileStore.js';
 import type {ThumbnailEntityType} from './contracts.js';
 import {THUMBNAIL_WORKER_CONFIG} from './config.js';
+import {
+  isDuplicateJobIdError,
+  shouldReuseExistingThumbnailJob,
+  thumbnailRenderJobId,
+  ThumbnailQueueUnavailableError,
+} from './producerHelpers.js';
 
-export class ThumbnailQueueUnavailableError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = 'ThumbnailQueueUnavailableError';
-  }
-}
+export {
+  shouldReuseExistingThumbnailJob,
+  ThumbnailQueueUnavailableError,
+} from './producerHelpers.js';
 
 export interface EnqueueThumbnailRenderInput {
   entityType: ThumbnailEntityType;
@@ -39,7 +42,11 @@ export async function enqueueThumbnailRender(
     const queue = getThumbnailRenderQueue();
     const jobId = thumbnailRenderJobId(input.outputFileName);
     const existingJob = await queue.getJob(jobId);
-    if (existingJob) return existingJob;
+    if (existingJob) {
+      const state = await existingJob.getState();
+      if (shouldReuseExistingThumbnailJob(state)) return existingJob;
+      await existingJob.remove().catch(() => undefined);
+    }
 
     const [waiting, delayed] = await Promise.all([
       queue.getWaitingCount(),
@@ -54,20 +61,28 @@ export async function enqueueThumbnailRender(
     const inputFileName = `${input.outputFileName.slice(0, -4)}.html`;
     await writeHtmlInputAtomically(inputFileName, input.html);
 
-    return await addThumbnailRenderJob(
-      {
-        version: 1,
-        requestId: input.requestId || randomUUID(),
-        entityType: input.entityType,
-        entityId: String(input.entityId),
-        inputFileName,
-        outputFileName: input.outputFileName,
-        width: input.width,
-        height: input.height,
-        enqueuedAt: new Date().toISOString(),
-      },
-      jobOptions,
-    );
+    try {
+      return await addThumbnailRenderJob(
+        {
+          version: 1,
+          requestId: input.requestId || randomUUID(),
+          entityType: input.entityType,
+          entityId: String(input.entityId),
+          inputFileName,
+          outputFileName: input.outputFileName,
+          width: input.width,
+          height: input.height,
+          enqueuedAt: new Date().toISOString(),
+        },
+        jobOptions,
+      );
+    } catch (error) {
+      if (isDuplicateJobIdError(error)) {
+        const raced = await queue.getJob(jobId);
+        if (raced) return raced;
+      }
+      throw error;
+    }
   } catch (error) {
     if (error instanceof ThumbnailQueueUnavailableError) throw error;
     throw new ThumbnailQueueUnavailableError('Thumbnail render queue is unavailable', {

--- a/src/externalServices/thumbnailWorker/producerHelpers.ts
+++ b/src/externalServices/thumbnailWorker/producerHelpers.ts
@@ -1,0 +1,23 @@
+export class ThumbnailQueueUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ThumbnailQueueUnavailableError';
+  }
+}
+
+export function shouldReuseExistingThumbnailJob(state: string): boolean {
+  return state === 'waiting'
+    || state === 'delayed'
+    || state === 'active'
+    || state === 'paused'
+    || state === 'waiting-children'
+    || state === 'prioritized';
+}
+
+export function isDuplicateJobIdError(error: unknown): boolean {
+  return error instanceof Error && /job.*(already exists|exists already)/i.test(error.message);
+}
+
+export function thumbnailRenderJobId(outputFileName: string): string {
+  return `render_${outputFileName.replace(/[^A-Za-z0-9_-]/g, '_')}`;
+}

--- a/src/externalServices/thumbnailWorker/puppeteerRenderer.ts
+++ b/src/externalServices/thumbnailWorker/puppeteerRenderer.ts
@@ -16,16 +16,29 @@ class PuppeteerTimeoutError extends Error {
   }
 }
 
-async function withTimeout<T>(operation: string, timeoutMs: number, promise: Promise<T>): Promise<T> {
+async function withTimeout<T>(
+  operation: string,
+  timeoutMs: number,
+  promise: Promise<T>,
+  onTimeout?: () => void,
+): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => reject(new PuppeteerTimeoutError(operation, timeoutMs)), timeoutMs);
+    timer = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } catch {
+        // Best-effort abort; the timeout error is the one callers handle.
+      }
+      reject(new PuppeteerTimeoutError(operation, timeoutMs));
+    }, timeoutMs);
   });
 
   try {
     return await Promise.race([promise, timeout]);
   } finally {
     if (timer) clearTimeout(timer);
+    void promise.catch(() => undefined);
   }
 }
 
@@ -123,11 +136,15 @@ export class PuppeteerRenderer {
         let page: Page | null = null;
 
         try {
-          page = await withTimeout(
+          const openedPage = await withTimeout(
             'Puppeteer page creation',
             PAGE_CREATE_TIMEOUT_MS,
             browser.newPage(),
           );
+          page = openedPage;
+          const abortPage = () => {
+            void openedPage.close().catch(() => undefined);
+          };
           page.on('error', error => logger.warn('[thumbnail-worker] page error', error));
           page.on('console', message => logger.debug('[thumbnail-worker] page console', message.text()));
 
@@ -135,21 +152,25 @@ export class PuppeteerRenderer {
             'Puppeteer JavaScript setup',
             PAGE_SETUP_TIMEOUT_MS,
             page.setJavaScriptEnabled(false),
+            abortPage,
           );
           await withTimeout(
             'Puppeteer viewport setup',
             PAGE_SETUP_TIMEOUT_MS,
             page.setViewport({width, height}),
+            abortPage,
           );
           await withTimeout(
             'Puppeteer HTML rendering',
             PAGE_CONTENT_TIMEOUT_MS,
             page.setContent(html, {timeout: PAGE_CONTENT_TIMEOUT_MS, waitUntil: 'load'}),
+            abortPage,
           );
           const screenshot = await withTimeout(
             'Puppeteer screenshot',
             SCREENSHOT_TIMEOUT_MS,
             page.screenshot({type: 'png', omitBackground: true}),
+            abortPage,
           );
           return Buffer.from(screenshot);
         } catch (error) {

--- a/src/externalServices/thumbnailWorker/queue.ts
+++ b/src/externalServices/thumbnailWorker/queue.ts
@@ -8,6 +8,7 @@ import {
   type ThumbnailRenderJobResult,
 } from './contracts.js';
 import {registerShutdownStep} from '@/server/bootstrap/shutdownCoordinator.js';
+import {thumbnailRenderJobId} from './producerHelpers.js';
 
 let queue: Queue<ThumbnailRenderJobData, ThumbnailRenderJobResult> | null = null;
 let queueEvents: QueueEvents | null = null;
@@ -50,9 +51,7 @@ export async function addThumbnailRenderJob(
   });
 }
 
-export function thumbnailRenderJobId(outputFileName: string): string {
-  return `render_${outputFileName.replace(/[^A-Za-z0-9_-]/g, '_')}`;
-}
+export {thumbnailRenderJobId} from './producerHelpers.js';
 
 export async function closeThumbnailQueueClients(): Promise<void> {
   const clients = [queueEvents?.close(), queue?.close()].filter(Boolean) as Promise<void>[];

--- a/src/externalServices/thumbnailWorker/renderClient.test.ts
+++ b/src/externalServices/thumbnailWorker/renderClient.test.ts
@@ -2,12 +2,13 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import type {Response} from 'express';
 import {
+  awaitThumbnailGeneration,
   resolveThumbnailWaitMs,
   sendThumbnailRenderError,
+  thumbnailGenerationWaitMs,
   ThumbnailRenderPendingError,
 } from './renderClient.js';
-import {ThumbnailQueueUnavailableError} from './producer.js';
-import {thumbnailRenderJobId} from './queue.js';
+import {ThumbnailQueueUnavailableError, thumbnailRenderJobId} from './producerHelpers.js';
 
 function responseRecorder() {
   const recorded = {
@@ -41,6 +42,7 @@ test('normal and OpenGraph requests use bounded wait contracts', () => {
   assert.equal(resolveThumbnailWaitMs(undefined), 5000);
   assert.equal(resolveThumbnailWaitMs('anything-else'), 5000);
   assert.equal(resolveThumbnailWaitMs('og'), 15000);
+  assert.equal(thumbnailGenerationWaitMs(), 600_000);
 });
 
 test('pending render maps to retryable 204 without cancelling the job', () => {
@@ -72,4 +74,48 @@ test('render job IDs deduplicate matching output without colliding entity types'
     thumbnailRenderJobId('level_69_LARGE.png'),
     thumbnailRenderJobId('rating_69_LARGE.png'),
   );
+});
+
+test('HTTP timeout does not restart in-flight thumbnail generation', async () => {
+  const key = `in-flight-${Date.now()}-${Math.random()}`;
+  let produceCount = 0;
+  const produce = async () => {
+    produceCount += 1;
+    await new Promise(resolve => setTimeout(resolve, 120));
+    return Buffer.from('png');
+  };
+
+  await assert.rejects(
+    () => awaitThumbnailGeneration({key, waitMs: 20, produce}),
+    (error: unknown) => error instanceof ThumbnailRenderPendingError,
+  );
+  await assert.rejects(
+    () => awaitThumbnailGeneration({key, waitMs: 20, produce}),
+    (error: unknown) => error instanceof ThumbnailRenderPendingError,
+  );
+
+  const result = await awaitThumbnailGeneration({key, waitMs: 250, produce});
+  assert.equal(produceCount, 1);
+  assert.equal(result.toString(), 'png');
+});
+
+test('concurrent callers share a single thumbnail produce()', async () => {
+  const key = `shared-${Date.now()}-${Math.random()}`;
+  let produceCount = 0;
+  const produce = async () => {
+    produceCount += 1;
+    await new Promise(resolve => setTimeout(resolve, 40));
+    return Buffer.from('shared');
+  };
+
+  const [first, second, third] = await Promise.all([
+    awaitThumbnailGeneration({key, waitMs: 200, produce}),
+    awaitThumbnailGeneration({key, waitMs: 200, produce}),
+    awaitThumbnailGeneration({key, waitMs: 200, produce}),
+  ]);
+
+  assert.equal(produceCount, 1);
+  assert.equal(first.toString(), 'shared');
+  assert.equal(second.toString(), 'shared');
+  assert.equal(third.toString(), 'shared');
 });

--- a/src/externalServices/thumbnailWorker/renderClient.ts
+++ b/src/externalServices/thumbnailWorker/renderClient.ts
@@ -3,15 +3,14 @@ import path from 'node:path';
 import type {Request, Response} from 'express';
 import type {ThumbnailEntityType} from './contracts.js';
 import {THUMBNAIL_WORKER_CONFIG} from './config.js';
-import {enqueueThumbnailRender, ThumbnailQueueUnavailableError} from './producer.js';
+import {ThumbnailQueueUnavailableError} from './producerHelpers.js';
 import {outputPath} from './fileStore.js';
+import {
+  ThumbnailRenderPendingError,
+} from './generationCoalesce.js';
 
-export class ThumbnailRenderPendingError extends Error {
-  constructor(readonly waitMs: number) {
-    super(`Thumbnail render is still processing after ${waitMs}ms`);
-    this.name = 'ThumbnailRenderPendingError';
-  }
-}
+export {ThumbnailRenderPendingError, awaitThumbnailGeneration} from './generationCoalesce.js';
+export {ThumbnailQueueUnavailableError} from './producerHelpers.js';
 
 interface RenderHtmlOptions {
   entityType: ThumbnailEntityType;
@@ -58,9 +57,12 @@ export function thumbnailWaitMs(req: Request): number {
   return resolveThumbnailWaitMs(req.query.wait);
 }
 
-export function thumbnailGenerationKey(base: string, req: Request): string {
-  if (THUMBNAIL_WORKER_CONFIG.renderMode === 'local') return base;
-  return `${base}-queue-${thumbnailWaitMs(req)}`;
+export function thumbnailGenerationWaitMs(): number {
+  return THUMBNAIL_WORKER_CONFIG.generationWaitMs;
+}
+
+export function thumbnailGenerationKey(base: string): string {
+  return base;
 }
 
 export async function renderHtmlToPng(options: RenderHtmlOptions): Promise<Buffer> {
@@ -71,6 +73,7 @@ export async function renderHtmlToPng(options: RenderHtmlOptions): Promise<Buffe
   const existing = await readOutputIfPresent(options.outputFileName);
   if (existing) return existing;
 
+  const {enqueueThumbnailRender} = await import('./producer.js');
   await enqueueThumbnailRender({
     entityType: options.entityType,
     entityId: options.entityId,

--- a/src/server/routes/v2/misc/media.ts
+++ b/src/server/routes/v2/misc/media.ts
@@ -28,8 +28,10 @@ import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
 import thumbnailsRouter from './thumbnails.js';
 import {
+  awaitThumbnailGeneration,
   renderHtmlToPng,
   sendThumbnailRenderError,
+  thumbnailGenerationWaitMs,
   thumbnailWaitMs,
 } from '@/externalServices/thumbnailWorker/renderClient.js';
 import {THUMBNAIL_WORKER_CONFIG} from '@/externalServices/thumbnailWorker/config.js';
@@ -1362,6 +1364,10 @@ router.get(
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     }
 
+    const buffer = await awaitThumbnailGeneration({
+      key: `wheel-${seed}`,
+      waitMs: thumbnailWaitMs(req),
+      produce: async () => {
     // Get levels with the same seed logic
     const levels = await Level.findAll({
       where: {
@@ -1448,17 +1454,20 @@ router.get(
       </html>
     `;
 
-    const buffer = await renderHtmlToPng({
+    const png = await renderHtmlToPng({
       entityType: 'wheel',
       entityId: seed,
       html,
       outputFileName: wheelOutputFileName,
       width,
       height,
-      waitMs: thumbnailWaitMs(req),
+      waitMs: thumbnailGenerationWaitMs(),
       localRender: () => htmlToPng(html, width, height),
     });
-    await writePngOutputAtomically(wheelOutputFileName, buffer);
+    await writePngOutputAtomically(wheelOutputFileName, png);
+    return png;
+      },
+    });
 
     res.set('Content-Type', 'image/png');
     return res.send(buffer);

--- a/src/server/routes/v2/misc/thumbnails.ts
+++ b/src/server/routes/v2/misc/thumbnails.ts
@@ -34,19 +34,18 @@ import { getSongDisplayName, getArtistDisplayName, formatDuration } from '@/misc
 import Song from '@/models/songs/Song.js';
 import Artist from '@/models/artists/Artist.js';
 import {
+  awaitThumbnailGeneration,
   outputFileNameFromPath,
   renderHtmlToPng,
   sendThumbnailRenderError,
   thumbnailGenerationKey,
+  thumbnailGenerationWaitMs,
   thumbnailWaitMs,
 } from '@/externalServices/thumbnailWorker/renderClient.js';
 
 dotenv.config();
 
 const CACHE_PATH = process.env.CACHE_PATH || path.join(process.cwd(), 'cache');
-
-// Promise map for tracking ongoing thumbnail generation
-const thumbnailGenerationPromises = new Map<string, Promise<Buffer>>();
 
 // Define size presets
 const THUMBNAIL_SIZES = {
@@ -119,24 +118,8 @@ function cleanExpiredCacheDirectory(directory: string): void {
   }
 }
 
-// Function to clean all expired cache files
 function cleanAllExpiredCache(): void {
   cleanExpiredCacheDirectory(THUMBNAILS_CACHE_DIR);
-
-  // Also clean up any stale promises that might be hanging around
-  const now = Date.now();
-  const MAX_PROMISE_AGE = 5 * 60 * 1000; // 5 minutes
-
-  // Add timestamp to promises if not present
-  for (const [key, promise] of thumbnailGenerationPromises.entries()) {
-    if (!(promise as any).__timestamp) {
-      (promise as any).__timestamp = now;
-    } else if (now - (promise as any).__timestamp > MAX_PROMISE_AGE) {
-      // Clean up promises older than MAX_PROMISE_AGE
-      logger.debug(`Removing stale thumbnail generation promise for ${key}`);
-      thumbnailGenerationPromises.delete(key);
-    }
-  }
 }
 
 // Start periodic cleanup
@@ -176,8 +159,8 @@ async function resolvePackId(param: string): Promise<number | null> {
   return null;
 }
 
-// Set EXPORT_THUMBNAIL_HTML=false to disable. Default: on (local review of generated cards).
-const EXPORT_THUMBNAIL_HTML = process.env.EXPORT_THUMBNAIL_HTML !== 'false';
+// Set EXPORT_THUMBNAIL_HTML=true to dump generated cards for local review.
+const EXPORT_THUMBNAIL_HTML = process.env.EXPORT_THUMBNAIL_HTML === 'true';
 
 // Function to export HTML to file for review
 async function exportHtmlToFile(html: string, entityType: 'level' | 'player' | 'pass' | 'pack' | 'rating', entityId: number | string): Promise<void> {
@@ -296,7 +279,6 @@ const handleLevelStyleThumbnail = async (req: Request, res: Response) => {
       : getThumbnailPath(levelId, 'LARGE');
     const promiseKey = thumbnailGenerationKey(
       `${isRatingEmbed ? 'rating' : 'level'}-${levelId}`,
-      req,
     );
 
     // Clean expired cache file
@@ -308,32 +290,10 @@ const handleLevelStyleThumbnail = async (req: Request, res: Response) => {
       logWithCondition(`Using cached LARGE thumbnail for level ${levelId}`, 'thumbnail');
       largeBuffer = await fs.promises.readFile(largeCachePath);
     } else {
-      // Check if generation is already in progress
-      if (thumbnailGenerationPromises.has(promiseKey)) {
-        logWithCondition(`Thumbnail generation for level ${levelId} already in progress, waiting...`, 'thumbnail');
-        try {
-          largeBuffer = await thumbnailGenerationPromises.get(promiseKey)!;
-
-          // Verify the file was actually saved
-          if (!fs.existsSync(largeCachePath)) {
-            logger.warn(`Promise resolved but thumbnail file not found for level ${levelId}, regenerating...`);
-            // Remove the promise and continue to regeneration
-            thumbnailGenerationPromises.delete(promiseKey);
-          } else {
-            logWithCondition(`Successfully obtained thumbnail from concurrent generation for level ${levelId}`, 'thumbnail');
-          }
-        } catch (error) {
-          if (error instanceof Error && !error.message.includes('Video details not found')) {
-            logger.warn(`Error while waiting for concurrent thumbnail generation for level ${levelId}:`, error);
-          }
-          thumbnailGenerationPromises.delete(promiseKey);
-        }
-      }
-
-      // If we don't have the buffer yet (no concurrent generation or it failed)
-      if (!largeBuffer) {
-        // Create a new generation promise
-        const generationPromise = (async () => {
+      largeBuffer = await awaitThumbnailGeneration({
+        key: promiseKey,
+        waitMs: thumbnailWaitMs(req),
+        produce: async () => {
           logWithCondition(`Generating new thumbnail for level ${levelId}`, 'thumbnail');
 
           const level = await Level.findOne({
@@ -826,7 +786,7 @@ const handleLevelStyleThumbnail = async (req: Request, res: Response) => {
             outputFileName: outputFileNameFromPath(largeCachePath),
             width,
             height,
-            waitMs: thumbnailWaitMs(req),
+            waitMs: thumbnailGenerationWaitMs(),
             localRender: () => htmlToPng(html, width, height),
           });
 
@@ -835,23 +795,8 @@ const handleLevelStyleThumbnail = async (req: Request, res: Response) => {
           logWithCondition(`Saved LARGE thumbnail for level ${levelId} to cache`, 'thumbnail');
 
           return buffer;
-        })();
-
-        // Store the promise in the map
-        thumbnailGenerationPromises.set(promiseKey, generationPromise);
-
-        try {
-          // Wait for the generation to complete
-          largeBuffer = await generationPromise;
-        } catch (error) {
-          // If any error occurs, clean up the promise and rethrow
-          thumbnailGenerationPromises.delete(promiseKey);
-          throw error;
-        }
-
-        // Clean up the promise after successful completion
-        thumbnailGenerationPromises.delete(promiseKey);
-      }
+        },
+      });
     }
 
     // Validate buffer exists and is valid
@@ -984,7 +929,7 @@ router.get(
     logWithCondition(`Thumbnail requested for player ${playerId} with size ${size}`, 'thumbnail');
 
     const largeCachePath = getThumbnailPathForEntity(playerId, 'player', 'LARGE');
-    const promiseKey = thumbnailGenerationKey(`player-${playerId}`, req);
+    const promiseKey = thumbnailGenerationKey(`player-${playerId}`);
 
     cleanExpiredCache(largeCachePath);
 
@@ -993,24 +938,10 @@ router.get(
       logWithCondition(`Using cached LARGE thumbnail for player ${playerId}`, 'thumbnail');
       largeBuffer = await fs.promises.readFile(largeCachePath);
     } else {
-      if (thumbnailGenerationPromises.has(promiseKey)) {
-        logWithCondition(`Thumbnail generation for player ${playerId} already in progress, waiting...`, 'thumbnail');
-        try {
-          largeBuffer = await thumbnailGenerationPromises.get(promiseKey)!;
-          if (!fs.existsSync(largeCachePath)) {
-            logger.warn(`Promise resolved but thumbnail file not found for player ${playerId}, regenerating...`);
-            thumbnailGenerationPromises.delete(promiseKey);
-          } else {
-            logWithCondition(`Successfully obtained thumbnail from concurrent generation for player ${playerId}`, 'thumbnail');
-          }
-        } catch (error) {
-          logger.warn(`Error while waiting for concurrent thumbnail generation for player ${playerId}:`, error);
-          thumbnailGenerationPromises.delete(promiseKey);
-        }
-      }
-
-      if (!largeBuffer) {
-        const generationPromise = (async () => {
+      largeBuffer = await awaitThumbnailGeneration({
+        key: promiseKey,
+        waitMs: thumbnailWaitMs(req),
+        produce: async () => {
           logWithCondition(`Generating new thumbnail for player ${playerId}`, 'thumbnail');
 
           const {width, height, multiplier} = THUMBNAIL_SIZES.LARGE;
@@ -1142,26 +1073,15 @@ router.get(
             outputFileName: outputFileNameFromPath(largeCachePath),
             width,
             height,
-            waitMs: thumbnailWaitMs(req),
+            waitMs: thumbnailGenerationWaitMs(),
             localRender: () => htmlToPng(html, width, height),
           });
           await fs.promises.writeFile(largeCachePath, buffer);
           logWithCondition(`Saved LARGE thumbnail for player ${playerId} to cache`, 'thumbnail');
 
           return buffer;
-        })();
-
-        thumbnailGenerationPromises.set(promiseKey, generationPromise);
-
-        try {
-          largeBuffer = await generationPromise;
-        } catch (error) {
-          thumbnailGenerationPromises.delete(promiseKey);
-          throw error;
-        }
-
-        thumbnailGenerationPromises.delete(promiseKey);
-      }
+        },
+      });
     }
 
     // Validate buffer exists and is valid
@@ -1258,7 +1178,7 @@ router.get(
     logWithCondition(`Thumbnail requested for pass ${passId} with size ${size}`, 'thumbnail');
 
     const largeCachePath = getThumbnailPathForEntity(passId, 'pass', 'LARGE');
-    const promiseKey = thumbnailGenerationKey(`pass-${passId}`, req);
+    const promiseKey = thumbnailGenerationKey(`pass-${passId}`);
 
     cleanExpiredCache(largeCachePath);
 
@@ -1267,24 +1187,10 @@ router.get(
       logWithCondition(`Using cached LARGE thumbnail for pass ${passId}`, 'thumbnail');
       largeBuffer = await fs.promises.readFile(largeCachePath);
     } else {
-      if (thumbnailGenerationPromises.has(promiseKey)) {
-        logWithCondition(`Thumbnail generation for pass ${passId} already in progress, waiting...`, 'thumbnail');
-        try {
-          largeBuffer = await thumbnailGenerationPromises.get(promiseKey)!;
-          if (!fs.existsSync(largeCachePath)) {
-            logger.warn(`Promise resolved but thumbnail file not found for pass ${passId}, regenerating...`);
-            thumbnailGenerationPromises.delete(promiseKey);
-          } else {
-            logWithCondition(`Successfully obtained thumbnail from concurrent generation for pass ${passId}`, 'thumbnail');
-          }
-        } catch (error) {
-          logger.warn(`Error while waiting for concurrent thumbnail generation for pass ${passId}:`, error);
-          thumbnailGenerationPromises.delete(promiseKey);
-        }
-      }
-
-      if (!largeBuffer) {
-        const generationPromise = (async () => {
+      largeBuffer = await awaitThumbnailGeneration({
+        key: promiseKey,
+        waitMs: thumbnailWaitMs(req),
+        produce: async () => {
           logWithCondition(`Generating new thumbnail for pass ${passId}`, 'thumbnail');
 
           const {width, height, multiplier} = THUMBNAIL_SIZES.LARGE;
@@ -1429,26 +1335,15 @@ router.get(
             outputFileName: outputFileNameFromPath(largeCachePath),
             width,
             height,
-            waitMs: thumbnailWaitMs(req),
+            waitMs: thumbnailGenerationWaitMs(),
             localRender: () => htmlToPng(html, width, height),
           });
           await fs.promises.writeFile(largeCachePath, buffer);
           logWithCondition(`Saved LARGE thumbnail for pass ${passId} to cache`, 'thumbnail');
 
           return buffer;
-        })();
-
-        thumbnailGenerationPromises.set(promiseKey, generationPromise);
-
-        try {
-          largeBuffer = await generationPromise;
-        } catch (error) {
-          thumbnailGenerationPromises.delete(promiseKey);
-          throw error;
-        }
-
-        thumbnailGenerationPromises.delete(promiseKey);
-      }
+        },
+      });
     }
 
     // Validate buffer exists and is valid
@@ -1577,7 +1472,7 @@ router.get(
     logWithCondition(`Thumbnail requested for pack ${resolvedPackId} with size ${size}`, 'thumbnail');
 
     const largeCachePath = getThumbnailPathForEntity(resolvedPackId, 'pack', 'LARGE');
-    const promiseKey = thumbnailGenerationKey(`pack-${resolvedPackId}`, req);
+    const promiseKey = thumbnailGenerationKey(`pack-${resolvedPackId}`);
 
     cleanExpiredCache(largeCachePath);
 
@@ -1586,24 +1481,10 @@ router.get(
       logWithCondition(`Using cached LARGE thumbnail for pack ${resolvedPackId}`, 'thumbnail');
       largeBuffer = await fs.promises.readFile(largeCachePath);
     } else {
-      if (thumbnailGenerationPromises.has(promiseKey)) {
-        logWithCondition(`Thumbnail generation for pack ${resolvedPackId} already in progress, waiting...`, 'thumbnail');
-        try {
-          largeBuffer = await thumbnailGenerationPromises.get(promiseKey)!;
-          if (!fs.existsSync(largeCachePath)) {
-            logger.warn(`Promise resolved but thumbnail file not found for pack ${resolvedPackId}, regenerating...`);
-            thumbnailGenerationPromises.delete(promiseKey);
-          } else {
-            logWithCondition(`Successfully obtained thumbnail from concurrent generation for pack ${resolvedPackId}`, 'thumbnail');
-          }
-        } catch (error) {
-          logger.warn(`Error while waiting for concurrent thumbnail generation for pack ${resolvedPackId}:`, error);
-          thumbnailGenerationPromises.delete(promiseKey);
-        }
-      }
-
-      if (!largeBuffer) {
-        const generationPromise = (async () => {
+      largeBuffer = await awaitThumbnailGeneration({
+        key: promiseKey,
+        waitMs: thumbnailWaitMs(req),
+        produce: async () => {
           logWithCondition(`Generating new thumbnail for pack ${resolvedPackId}`, 'thumbnail');
 
           const {width, height, multiplier} = THUMBNAIL_SIZES.LARGE;
@@ -1923,26 +1804,15 @@ router.get(
             outputFileName: outputFileNameFromPath(largeCachePath),
             width,
             height,
-            waitMs: thumbnailWaitMs(req),
+            waitMs: thumbnailGenerationWaitMs(),
             localRender: () => htmlToPng(html, width, height),
           });
           await fs.promises.writeFile(largeCachePath, buffer);
           logWithCondition(`Saved LARGE thumbnail for pack ${resolvedPackId} to cache`, 'thumbnail');
 
           return buffer;
-        })();
-
-        thumbnailGenerationPromises.set(promiseKey, generationPromise);
-
-        try {
-          largeBuffer = await generationPromise;
-        } catch (error) {
-          thumbnailGenerationPromises.delete(promiseKey);
-          throw error;
-        }
-
-        thumbnailGenerationPromises.delete(promiseKey);
-      }
+        },
+      });
     }
 
     // Validate buffer exists and is valid


### PR DESCRIPTION
- Introduced `isClientAbortError` function to identify client abort errors during streaming.
- Updated `streamStorageObjectResponse` to gracefully handle client aborts without throwing errors.
- Enhanced tests to cover scenarios for client aborts and error matching.
- Refactored routes to utilize the new error handling for improved robustness in response streaming.